### PR TITLE
upgrade composer/installers to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "composer/installers": "^1.0.0"
+        "composer/installers": "^2.0"
     },
     "require-dev": {
         "cakephp/cakephp-codesniffer": "^1.0.0"


### PR DESCRIPTION
## Issue


## Description
composer/installers を 2.0 にするだけ
これを参照すればDeprecatedは消える
ref: https://github.com/thecocojp/cocoreview/actions/runs/15648403410/job/44090319157?pr=24359